### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Typst 📦
-        uses: yusancky/setup-typst@v2
-        id: setup-typst
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'v0.9.0'
+          typst-version: 'v0.9.0'
 
       - name: Clone BoneDocument/BoneDocument 📦
         uses: GuillaumeFalourd/clone-github-repo-action@v2.2


### PR DESCRIPTION
操作 `yusancky/setup-typst` 已迁移至仓库 `typst-community/setup-typst`，目前最新版本为 v4。前往 [公告（中文）](https://github.com/yusancky/setup-typst/blob/main/announcement_zh-Hans-CN.md) 了解更多信息。